### PR TITLE
Update test scripts to Pester v4+ Syntax

### DIFF
--- a/tests/Module.Manifest.Tests.ps1
+++ b/tests/Module.Manifest.Tests.ps1
@@ -7,22 +7,22 @@ Describe "<%=$PLASTER_PARAM_ModuleName%> Module Manifest" {
   Context "Manifest Validation." {
     
     It "Has a valid manifest." {
-      { Test-ModuleManifest -Path $ModuleManifestPath -ErrorAction Stop -WarningAction SilentlyContinue } | Should Not Throw
+      { Test-ModuleManifest -Path $ModuleManifestPath -ErrorAction Stop -WarningAction SilentlyContinue } | Should -Not -Throw
     }
     It 'Has a valid root module.' {
-      $Manifest.RootModule | Should Be "$ModuleName.psm1"
+      $Manifest.RootModule | Should -Be "$ModuleName.psm1"
     }
     It 'Has a valid version in the manifest.' {
-      $Manifest.ModuleVersion -as [Version] | Should Not BeNullOrEmpty
+      $Manifest.ModuleVersion -as [Version] | Should -Not -BeNullOrEmpty
     }
     It 'Has a valid author.' {
-      $Manifest.Author | Should Not BeNullOrEmpty
+      $Manifest.Author | Should -Not -BeNullOrEmpty
     }
     It 'Has a valid guid.' {
-      { [guid]::Parse($Manifest.Guid) } | Should Not throw
+      { [guid]::Parse($Manifest.Guid) } | Should -Not -Throw
     }
     It 'Has a valid copyright.' {
-      $Manifest.Copyright | Should Not BeNullOrEmpty
+      $Manifest.Copyright | Should -Not -BeNullOrEmpty
     }
     
   }

--- a/tests/private/Add-PrivateFunction.Tests.ps1
+++ b/tests/private/Add-PrivateFunction.Tests.ps1
@@ -7,7 +7,7 @@ Describe 'Add-PrivateFunction' {
     Context "When not passed any parameters." {
 
       It 'Should write correct output.' {
-        Add-PrivateFunction | Should Be "Your private function ran!"
+        Add-PrivateFunction | Should -Be "Your private function ran!"
       }
 
     }

--- a/tests/public/Add-YourFirstFunction.Tests.ps1
+++ b/tests/public/Add-YourFirstFunction.Tests.ps1
@@ -5,7 +5,7 @@ Describe 'Add-YourFirstFunction' {
   Context "When not passed any parameters." {
 
     It 'Should write correct output.' {
-      Add-YourFirstFunction | Should Be "Your first function ran!"
+      Add-YourFirstFunction | Should -Be "Your first function ran!"
     }
 
   }


### PR DESCRIPTION
Hi Chris,

I've found this template to be a great starting point to get a handle on building a PowerShell Module, and being able to publish it in PSGallery.  Along the way I've learnt a lot, so thanks for providing a starting point.

The updates to the test scripts address the Pester failures I get when I use this PowerShell Module Template.  This links to issue #1, which I created as a means of reporting this.

Given that you already specify a minimum Pester version of 4.7.3, this should not break anything if you are still using this version, since the Legacy method was Deprecated starting in version 4, and removed in version 5.

Hopefully you will find this a useful improvement.

Regards,

JohnB