### PR TITLE
Updated test file

### DIFF
--- a/tests/Module.Manifest.Tests.ps1
+++ b/tests/Module.Manifest.Tests.ps1
@@ -1,6 +1,8 @@
-. $PSScriptRoot\_InitializeTests.ps1
-
-$Manifest = Import-PowerShellDataFile -Path $ModuleManifestPath
+BeforeAll {
+  . $PSScriptRoot\_InitializeTests.ps1
+  $Manifest = Import-PowerShellDataFile -Path $ModuleManifestPath
+  Write-Verbose $Manifest
+}
 
 Describe "<%=$PLASTER_PARAM_ModuleName%> Module Manifest" {
   


### PR DESCRIPTION
Invoke-Build was failing with Pester 5.5 - it requires a BeforeAll section. Added a write-verbose to avoid an error (PSUseDeclaredVarsMoreThanAssignments) from the script analyzer. 

Now the generated module will compile without errors (tested in Powershell 7.4.0 with InvokeBuild 5.10.5 and Pester 5.5.0